### PR TITLE
Fix issue 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ cmake_minimum_required (VERSION 3.13)
 
 project(
   DrMock
-  VERSION 0.4.0
+  VERSION 0.4.1
   DESCRIPTION "C++17 testing and mocking framework"
   LANGUAGES CXX
 )

--- a/docs/samples/basic.md
+++ b/docs/samples/basic.md
@@ -467,3 +467,8 @@ Maybe `symbols.cpp` contains symbols required by a header included in
 `test.cpp`.
 Another common use-case is that of including `.qrc` files (Qt resource
 files) to the executable if they are required by the test.
+
+### Test names
+
+Test names must not contain the substring `DRTEST`; failing to follow
+this rule will result in compiler errors or undefined behavior.

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup
 setup(
     name = "DrMockGenerator",
     author = "Ole Kliemann, Malte Kliemann",
-    version = "0.4.0",
+    version = "0.4.1",
     scripts = ["DrMockGenerator"],
     packages = ["mocker"],
     include_package_data = True,

--- a/src/test/TestMacros.h
+++ b/src/test/TestMacros.h
@@ -35,11 +35,11 @@ FunctionInvoker name##_data_pusher{[] () { drutility::Singleton<Global>::get()->
 void name##Data()
 
 #define DRTEST_TEST(name) \
-void name(); \
+void name##_DRTEST_GUARD(); \
 namespace drtest { namespace detail { \
-FunctionInvoker name##_test_pusher{[] () { drutility::Singleton<Global>::get()->addTestFunc(#name, &name); }}; \
+FunctionInvoker name##_test_pusher{[] () { drutility::Singleton<Global>::get()->addTestFunc(#name, & name##_DRTEST_GUARD); }}; \
 }} \
-void name()
+void name##_DRTEST_GUARD()
 
 #define DRTEST_ASSERT(p) \
 do { if (not (p)) throw drtest::detail::TestFailure{__LINE__, #p}; } while (false)

--- a/tests/Test.cpp
+++ b/tests/Test.cpp
@@ -222,3 +222,10 @@ DRTEST_TEST(death_failure_wrong_raise)
 {
   DRTEST_ASSERT_TEST_FAIL(DRTEST_ASSERT_DEATH(raise(SIGXFSZ), SIGSEGV));
 }
+
+// Test that a test may be called the same an a drtest interface
+// function; see issue #7 for details.
+DRTEST_TEST(addRow)
+{
+  DRTEST_ASSERT(true);
+}


### PR DESCRIPTION
We fix #7 by adding `_DRTEST_GUARD` to the names of the test functions.