### PR TITLE
Tags

### DIFF
--- a/docs/samples/basic.md
+++ b/docs/samples/basic.md
@@ -482,3 +482,10 @@ macro `DRTEST_NAMESPACE` _before including_ `Test.h`:
 #include <DrMock/Test.h>
 ```
 
+### Row names
+
+Any `snake_case` or `camelCase` name may be used as row name, with the
+exception of the emtpy string. Avoid any name containing `DRTEST` or
+`DRMOCK`, or `ALL_CAPS` in general.
+
+Furthermore, duplicate row names are not allowed.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,8 @@ add_library(${PROJECT_NAME} SHARED
   test/Global.cpp
   test/TestObject.cpp
   test/FunctionInvoker.cpp
+  test/SkipTest.cpp
+  test/Interface.cpp
 )
 
 # This alias is required for the internal use of the `DrMock_module`

--- a/src/test/Global.cpp
+++ b/src/test/Global.cpp
@@ -166,4 +166,10 @@ Global::xfail()
   tests_[current_test_].xfail();
 }
 
+void
+Global::tagRow(const std::string& row, tags::Tag tag)
+{
+  tests_[current_test_].tagRow(row, tag);
+}
+
 }} // namespaces

--- a/src/test/Global.cpp
+++ b/src/test/Global.cpp
@@ -167,7 +167,7 @@ Global::xfail()
 }
 
 void
-Global::tagRow(const std::string& row, tags::Tag tag)
+Global::tagRow(const std::string& row, tags tag)
 {
   tests_[current_test_].tagRow(row, tag);
 }

--- a/src/test/Global.cpp
+++ b/src/test/Global.cpp
@@ -160,4 +160,10 @@ Global::runTestsAndLog()
   }
 }
 
+void
+Global::xfail()
+{
+  tests_[current_test_].xfail();
+}
+
 }} // namespaces

--- a/src/test/Global.h
+++ b/src/test/Global.h
@@ -24,6 +24,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Tags.h"
 #include "TestObject.h"
 #include "../utility/Singleton.h"
 
@@ -42,6 +43,7 @@ public:
   void runTestsAndLog();
   std::size_t num_failures() const;
   void xfail();
+  void tagRow(const std::string& row, tags::Tag tag);
 
 private:
   void addTest(std::string);

--- a/src/test/Global.h
+++ b/src/test/Global.h
@@ -41,6 +41,7 @@ public:
   template<typename T> T fetchData(const std::string& column);
   void runTestsAndLog();
   std::size_t num_failures() const;
+  void xfail();
 
 private:
   void addTest(std::string);

--- a/src/test/Global.h
+++ b/src/test/Global.h
@@ -43,7 +43,7 @@ public:
   void runTestsAndLog();
   std::size_t num_failures() const;
   void xfail();
-  void tagRow(const std::string& row, tags::Tag tag);
+  void tagRow(const std::string& row, tags tag);
 
 private:
   void addTest(std::string);

--- a/src/test/Global.tpp
+++ b/src/test/Global.tpp
@@ -29,7 +29,7 @@ template<typename... Ts>
 void
 Global::addRow(const std::string& row, Ts&&... ts)
 {
-  tests_[current_test_].addRow(row, 0, std::forward<Ts>(ts)...);
+  tests_[current_test_].addRow(row, std::forward<Ts>(ts)...);
 }
 
 template<typename T>

--- a/src/test/Interface.cpp
+++ b/src/test/Interface.cpp
@@ -5,7 +5,7 @@
 namespace drtest {
 
 void
-tagRow(const std::string& row, tags::Tag tag)
+tagRow(const std::string& row, tags tag)
 {
   drutility::Singleton<detail::Global>::get()->tagRow(row, tag);
 }

--- a/src/test/Interface.cpp
+++ b/src/test/Interface.cpp
@@ -5,6 +5,12 @@
 namespace drtest {
 
 void
+tagRow(const std::string& row, tags::Tag tag)
+{
+  drutility::Singleton<detail::Global>::get()->tagRow(row, tag);
+}
+
+void
 skip()
 {
   skip("");

--- a/src/test/Interface.cpp
+++ b/src/test/Interface.cpp
@@ -1,0 +1,25 @@
+#include "Interface.h"
+
+#include "SkipTest.h"
+
+namespace drtest {
+
+void
+skip()
+{
+  skip("");
+}
+
+void
+skip(std::string what)
+{
+  throw SkipTest{what};
+}
+
+void
+xfail()
+{
+  drutility::Singleton<detail::Global>::get()->xfail();
+}
+
+} // namespace drtest

--- a/src/test/Interface.h
+++ b/src/test/Interface.h
@@ -21,10 +21,13 @@
 
 #include <string>
 
+#include "Tags.h"
+
 namespace drtest {
 
 template<typename T> void addColumn(std::string);
 template<typename... Ts> void addRow(const std::string& row, Ts&&... ts);
+void tagRow(const std::string& row, tags::Tag);
 void skip();
 void skip(std::string what);
 void xfail();

--- a/src/test/Interface.h
+++ b/src/test/Interface.h
@@ -25,6 +25,9 @@ namespace drtest {
 
 template<typename T> void addColumn(std::string);
 template<typename... Ts> void addRow(const std::string& row, Ts&&... ts);
+void skip();
+void skip(std::string what);
+void xfail();
 
 } // namespace drtest
 

--- a/src/test/Interface.h
+++ b/src/test/Interface.h
@@ -27,7 +27,7 @@ namespace drtest {
 
 template<typename T> void addColumn(std::string);
 template<typename... Ts> void addRow(const std::string& row, Ts&&... ts);
-void tagRow(const std::string& row, tags::Tag);
+void tagRow(const std::string& row, tags tag);
 void skip();
 void skip(std::string what);
 void xfail();

--- a/src/test/SkipTest.cpp
+++ b/src/test/SkipTest.cpp
@@ -1,0 +1,16 @@
+#include "SkipTest.h"
+
+namespace drtest {
+
+SkipTest::SkipTest(std::string expr)
+:
+  what_{std::move(expr)}
+{}
+
+const char*
+SkipTest::what() const noexcept
+{
+  return what_.c_str();
+}
+
+} // namespace drtestßæ

--- a/src/test/SkipTest.h
+++ b/src/test/SkipTest.h
@@ -1,0 +1,22 @@
+#ifndef DRMOCK_SRC_TEST_SKIP_TEST_H
+#define DRMOCK_SRC_TEST_SKIP_TEST_H
+
+#include <stdexcept>
+#include <string>
+
+namespace drtest {
+
+class SkipTest : public std::exception
+{
+public:
+  SkipTest(std::string expr);
+
+  const char* what() const noexcept override;
+
+private:
+  std::string what_{};
+};
+
+} // namespace drtest
+
+#endif /* DRMOCK_SRC_TEST_SKIP_TEST_H */

--- a/src/test/Tags.h
+++ b/src/test/Tags.h
@@ -1,0 +1,15 @@
+#ifndef DRMOCK_SRC_TEST_TAG_H
+#define DRMOCK_SRC_TEST_TAG_H
+
+namespace drtest {
+
+enum Tag
+{
+  none = 0,
+  skip = (1 << 0),
+  xfail = (1 << 1)
+};
+
+} // namespace drtest
+
+#endif /* DRMOCK_SRC_TEST_TAG_H */

--- a/src/test/Tags.h
+++ b/src/test/Tags.h
@@ -1,15 +1,48 @@
 #ifndef DRMOCK_SRC_TEST_TAG_H
 #define DRMOCK_SRC_TEST_TAG_H
 
-namespace drtest { namespace tags {
+namespace drtest {
 
-enum Tag
+enum class tags
 {
   none = 0,
   skip = (1 << 0),
   xfail = (1 << 1)
 };
 
-}} // namespace drtest::tags
+inline tags
+operator|(tags lhs, tags rhs)
+{
+  return static_cast<tags>(
+      static_cast<std::underlying_type_t<tags>>(lhs) |
+      static_cast<std::underlying_type_t<tags>>(rhs)
+    );
+}
+
+inline tags
+operator&(tags lhs, tags rhs)
+{
+  return static_cast<tags>(
+      static_cast<std::underlying_type_t<tags>>(lhs) &
+      static_cast<std::underlying_type_t<tags>>(rhs)
+    );
+}
+
+inline tags&
+operator|=(tags& lhs, tags rhs)
+{
+  lhs = lhs | rhs;
+  return lhs;
+}
+
+inline tags&
+operator&=(tags& lhs, tags rhs)
+{
+  lhs = lhs & rhs;
+  return lhs;
+}
+
+
+} // namespace drtest
 
 #endif /* DRMOCK_SRC_TEST_TAG_H */

--- a/src/test/Tags.h
+++ b/src/test/Tags.h
@@ -1,7 +1,7 @@
 #ifndef DRMOCK_SRC_TEST_TAG_H
 #define DRMOCK_SRC_TEST_TAG_H
 
-namespace drtest {
+namespace drtest { namespace tags {
 
 enum Tag
 {
@@ -10,6 +10,6 @@ enum Tag
   xfail = (1 << 1)
 };
 
-} // namespace drtest
+}} // namespace drtest::tags
 
 #endif /* DRMOCK_SRC_TEST_TAG_H */

--- a/src/test/TestObject.cpp
+++ b/src/test/TestObject.cpp
@@ -169,4 +169,10 @@ TestObject::xfail()
   xfail_ = true;
 }
 
+void
+TestObject::tagRow(const std::string& row, tags::Tag tag)
+{
+  tags_[row] = static_cast<tags::Tag>(tags_[row] | tag);
+}
+
 }} // namespaces

--- a/src/test/TestObject.cpp
+++ b/src/test/TestObject.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 
 #include "../utility/ILogger.h"
+#include "SkipTest.h"
 #include "TestFailure.h"
 
 namespace drtest { namespace detail {
@@ -76,7 +77,7 @@ TestObject::runOneTest(const std::string& row, bool verbose_logging)
   {
     log("TEST", name_, row, -1, {});
   }
-  if (tags_[row] & Tag::skip)
+  if (tags_[row] & tags::skip)
   {
     log("SKIP", name_, row, -1, {});
     return;
@@ -85,9 +86,14 @@ TestObject::runOneTest(const std::string& row, bool verbose_logging)
   {
     test_func_();
   }
+  catch(const SkipTest& e)
+  {
+    log("SKIP", name_, row, -1, {});
+    return;
+  }
   catch(const TestFailure& e)
   {
-    if (tags_[row] & Tag::xfail)
+    if (xfail_ or (tags_[row] & tags::xfail))
     {
       log("XFAIL", name_, row, e.line(), e.what());
     }
@@ -155,6 +161,12 @@ std::size_t
 TestObject::num_failures() const
 {
   return failed_rows_.size();
+}
+
+void
+TestObject::xfail()
+{
+  xfail_ = true;
 }
 
 }} // namespaces

--- a/src/test/TestObject.cpp
+++ b/src/test/TestObject.cpp
@@ -77,7 +77,7 @@ TestObject::runOneTest(const std::string& row, bool verbose_logging)
   {
     log("TEST", name_, row, -1, {});
   }
-  if (tags_[row] & tags::skip)
+  if ((tags_[row] & tags::skip) == tags::skip)
   {
     log("SKIP", name_, row, -1, {});
     return;
@@ -93,7 +93,7 @@ TestObject::runOneTest(const std::string& row, bool verbose_logging)
   }
   catch(const TestFailure& e)
   {
-    if (xfail_ or (tags_[row] & tags::xfail))
+    if (xfail_ or ((tags_[row] & tags::xfail) == tags::xfail))
     {
       log("XFAIL", name_, row, e.line(), e.what());
     }
@@ -170,9 +170,9 @@ TestObject::xfail()
 }
 
 void
-TestObject::tagRow(const std::string& row, tags::Tag tag)
+TestObject::tagRow(const std::string& row, tags tag)
 {
-  tags_[row] = static_cast<tags::Tag>(tags_[row] | tag);
+  tags_[row] |= tag;
 }
 
 }} // namespaces

--- a/src/test/TestObject.cpp
+++ b/src/test/TestObject.cpp
@@ -76,14 +76,26 @@ TestObject::runOneTest(const std::string& row, bool verbose_logging)
   {
     log("TEST", name_, row, -1, {});
   }
+  if (tags_[row] & Tag::skip)
+  {
+    log("SKIP", name_, row, -1, {});
+    return;
+  }
   try
   {
     test_func_();
   }
   catch(const TestFailure& e)
   {
-    log("*FAIL", name_, row, e.line(), e.what());
-    failed_rows_.push_back(row);
+    if (tags_[row] & Tag::xfail)
+    {
+      log("XFAIL", name_, row, e.line(), e.what());
+    }
+    else
+    {
+      log("*FAIL", name_, row, e.line(), e.what());
+      failed_rows_.push_back(row);
+    }
     return;
   }
   catch(const std::logic_error& e)

--- a/src/test/TestObject.h
+++ b/src/test/TestObject.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <string>
 #include <typeindex>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -37,11 +38,7 @@ public:
   void setTestFunc(std::function<void()>);
   void setDataFunc(std::function<void()>);
   template<typename T> void addColumn(std::string);
-  template<typename T, typename... Ts> void addRow(
-      const std::string& row,
-      std::size_t i,
-      T&& t, Ts&&... ts
-    );
+  template<typename... Ts> void addRow(const std::string& row, Ts&&... ts);
   template<typename T> T fetchData(const std::string& column) const;
   void prepareTestData();
   void runTest(bool verbose_logging = true);
@@ -49,6 +46,17 @@ public:
 
 private:
   void runOneTest(const std::string& row, bool verbose_logging);
+
+  // Add the elements of the tuple `t` specified by `Is...` to `row`.
+  // Shall only be called from `addRow`.
+  template<typename Tuple, std::size_t... Is> void addRowImpl(
+      const std::string& row,
+      Tuple&& t,
+      const std::index_sequence<Is...>&
+    );
+  // Add `t` to the entry (`row`, `col`) of the data matrix. Shall only
+  // be called from `addRow`.
+  template<typename T> void addRowImpl(const std::string& row, std::size_t col, T&& t);
 
   std::string name_{};
   std::vector<std::string> data_columns_{};

--- a/src/test/TestObject.h
+++ b/src/test/TestObject.h
@@ -46,6 +46,7 @@ public:
   void runTest(bool verbose_logging = true);
   std::size_t num_failures() const;
   void xfail();
+  void tagRow(const std::string& row, tags::Tag tag);
 
 private:
   void runOneTest(const std::string& row, bool verbose_logging);

--- a/src/test/TestObject.h
+++ b/src/test/TestObject.h
@@ -27,6 +27,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Tags.h"
+
 namespace drtest { namespace detail {
 
 class TestObject
@@ -51,7 +53,7 @@ private:
   // Shall only be called from `addRow`.
   template<typename Tuple, std::size_t... Is> void addRowImpl(
       const std::string& row,
-      Tuple&& t,
+      Tuple t,
       const std::index_sequence<Is...>&
     );
   // Add `t` to the entry (`row`, `col`) of the data matrix. Shall only
@@ -68,6 +70,7 @@ private:
           std::string, // column
           std::any
         >> data_sets_{};
+  std::unordered_map<std::string, Tag> tags_{};  // row -> tags
   std::string current_row_{};
   std::function<void()> data_func_{};
   std::function<void()> test_func_{};

--- a/src/test/TestObject.h
+++ b/src/test/TestObject.h
@@ -46,7 +46,7 @@ public:
   void runTest(bool verbose_logging = true);
   std::size_t num_failures() const;
   void xfail();
-  void tagRow(const std::string& row, tags::Tag tag);
+  void tagRow(const std::string& row, tags tag);
 
 private:
   void runOneTest(const std::string& row, bool verbose_logging);
@@ -72,7 +72,7 @@ private:
           std::string, // column
           std::any
         >> data_sets_{};
-  std::unordered_map<std::string, tags::Tag> tags_{};  // row -> tags
+  std::unordered_map<std::string, tags> tags_{};  // row -> tags
   std::string current_row_{};
   std::function<void()> data_func_{};
   std::function<void()> test_func_{};

--- a/src/test/TestObject.h
+++ b/src/test/TestObject.h
@@ -45,6 +45,7 @@ public:
   void prepareTestData();
   void runTest(bool verbose_logging = true);
   std::size_t num_failures() const;
+  void xfail();
 
 private:
   void runOneTest(const std::string& row, bool verbose_logging);
@@ -70,11 +71,12 @@ private:
           std::string, // column
           std::any
         >> data_sets_{};
-  std::unordered_map<std::string, Tag> tags_{};  // row -> tags
+  std::unordered_map<std::string, tags::Tag> tags_{};  // row -> tags
   std::string current_row_{};
   std::function<void()> data_func_{};
   std::function<void()> test_func_{};
   std::vector<std::string> failed_rows_{};
+  bool xfail_{false};
 };
 
 }} // namespaces

--- a/src/test/TestObject.tpp
+++ b/src/test/TestObject.tpp
@@ -32,25 +32,40 @@ TestObject::addColumn(std::string column)
     });
 }
 
-template<typename T, typename... Ts>
+template<typename... Ts>
 void
-TestObject::addRow(const std::string& row, std::size_t i, T&& t, Ts&&... ts)
+TestObject::addRow(const std::string& row, Ts&&... ts)
 {
-  if ((sizeof...(ts) + 1) > data_columns_.size())
+  constexpr auto size = sizeof...(ts);
+  if (size > data_columns_.size())
   {
     throw std::logic_error{
         "adding row: \"" + row + "\"" +
-        ": with " + std::to_string((sizeof...(ts) + 1)) + " columns, " +
+        ": with " + std::to_string(size) + " columns, " +
         "can only have " + std::to_string(data_columns_.size())
       };
   }
+  data_rows_.push_back(row);
+  addRowImpl(
+      row,
+      std::forward_as_tuple(ts...),
+      std::make_index_sequence<size>{}
+    );
+}
 
-  if (i == 0)
-  {
-    data_rows_.push_back(row);
-  }
+template<typename Tuple, std::size_t... Is>
+void
+TestObject::addRowImpl(const std::string& row, Tuple&& t, const std::index_sequence<Is...>&)
+{
+  (addRowImpl(row, Is, std::forward<std::tuple_element_t<Is, Tuple>>(std::get<Is>(t))),
+   ...);
+}
 
-  const std::string& column = data_columns_[i];
+template<typename T>
+void
+TestObject::addRowImpl(const std::string& row, std::size_t col, T&& t)
+{
+  const std::string& column = data_columns_[col];
   auto type_it = data_column_types_.find(column);
   if (type_it == data_column_types_.end())
   {
@@ -71,11 +86,6 @@ TestObject::addRow(const std::string& row, std::size_t i, T&& t, Ts&&... ts)
   }
 
   data_sets_[row].insert({column, std::make_any<T>(std::forward<T>(t))});
-
-  if constexpr(sizeof...(ts) != 0)
-  {
-    addRow(row, i + 1, std::forward<Ts>(ts)...);
-  }
 }
 
 template<typename T>

--- a/src/test/TestObject.tpp
+++ b/src/test/TestObject.tpp
@@ -39,7 +39,7 @@ void
 TestObject::addRow(const std::string& row, Ts&&... ts)
 {
   constexpr auto size = sizeof...(ts);
-  if constexpr(std::is_same_v<drutility::last_t<Ts...>, Tag>)
+  if constexpr(std::is_same_v<drutility::last_t<Ts...>, tags::Tag>)
   {
     assert(size == (data_columns_.size() + 1));
     tags_[row] = std::get<size-1>(std::forward_as_tuple(ts...));
@@ -51,7 +51,7 @@ TestObject::addRow(const std::string& row, Ts&&... ts)
   }
   else
   {
-    tags_[row] = Tag::none;
+    tags_[row] = tags::none;
     addRowImpl(
         row,
         std::forward_as_tuple(ts...),

--- a/src/test/TestObject.tpp
+++ b/src/test/TestObject.tpp
@@ -73,6 +73,12 @@ TestObject::addRowImpl(const std::string& row, Tuple t, const std::index_sequenc
         "can only have " + std::to_string(data_columns_.size())
       };
   }
+  if (row.empty())
+  {
+    throw std::logic_error{
+        "adding row: \"" + row + "\"" + ": empty string not allowed as row name"
+      };
+  }
   if (std::find(data_rows_.begin(), data_rows_.end(), row) != data_rows_.end())
   {
     throw std::logic_error{

--- a/src/test/TestObject.tpp
+++ b/src/test/TestObject.tpp
@@ -73,6 +73,12 @@ TestObject::addRowImpl(const std::string& row, Tuple t, const std::index_sequenc
         "can only have " + std::to_string(data_columns_.size())
       };
   }
+  if (std::find(data_rows_.begin(), data_rows_.end(), row) != data_rows_.end())
+  {
+    throw std::logic_error{
+        "adding row: \"" + row + "\"" + ": row already present"
+      };
+  }
   data_rows_.push_back(row);
   (addRowImpl(row, Is, std::forward<std::tuple_element_t<Is, Tuple>>(std::get<Is>(t))),
    ...);

--- a/src/test/TestObject.tpp
+++ b/src/test/TestObject.tpp
@@ -39,7 +39,7 @@ void
 TestObject::addRow(const std::string& row, Ts&&... ts)
 {
   constexpr auto size = sizeof...(ts);
-  if constexpr(std::is_same_v<drutility::last_t<Ts...>, tags::Tag>)
+  if constexpr(std::is_same_v<drutility::last_t<Ts...>, tags>)
   {
     assert(size == (data_columns_.size() + 1));
     tags_[row] = std::get<size-1>(std::forward_as_tuple(ts...));

--- a/src/utility/Tuples.h
+++ b/src/utility/Tuples.h
@@ -1,0 +1,11 @@
+#ifndef DRMOCK_SRC_UTILITY_TUPLES_H
+#define DRMOCK_SRC_UTILITY_TUPLES_H
+
+namespace drutility {
+
+template<typename... Ts>
+using last_t = std::tuple_element_t<sizeof...(Ts) - 1, std::tuple<Ts...>>;
+
+} // namespace drtest
+
+#endif /* DRMOCK_SRC_UTILITY_TUPLES_H */

--- a/tests/Test.cpp
+++ b/tests/Test.cpp
@@ -291,3 +291,10 @@ DRTEST_TEST(rowCollision)
   test.addRow<int>("row", 1);
   DRTEST_ASSERT_THROW(test.addRow<int>("row", 2), std::logic_error);
 }
+
+DRTEST_TEST(emptyRowName)
+{
+  drtest::detail::TestObject test{"test"};
+  test.addColumn<int>("col");
+  DRTEST_ASSERT_THROW(test.addRow<int>("", 1), std::logic_error);
+}

--- a/tests/Test.cpp
+++ b/tests/Test.cpp
@@ -283,3 +283,11 @@ DRTEST_TEST(xfail)
   drtest::xfail();
   DRTEST_ASSERT_EQ(2 + 2, 5);
 }
+
+DRTEST_TEST(rowCollision)
+{
+  drtest::detail::TestObject test{"test"};
+  test.addColumn<int>("col");
+  test.addRow<int>("row", 1);
+  DRTEST_ASSERT_THROW(test.addRow<int>("row", 2), std::logic_error);
+}

--- a/tests/Test.cpp
+++ b/tests/Test.cpp
@@ -237,8 +237,8 @@ DRTEST_DATA(tags)
   drtest::addColumn<int>("expected");
 
   drtest::addRow("row 1", 1, 1, 2);
-  drtest::addRow("row 2", 2, 2, 5, drtest::Tag::skip);
-  drtest::addRow("row 3", 4, 4, 9, drtest::Tag::xfail);
+  drtest::addRow("row 2", 2, 2, 5, drtest::tags::skip);
+  drtest::addRow("row 3", 4, 4, 9, drtest::tags::xfail);
 }
 
 DRTEST_TEST(tags)
@@ -248,4 +248,16 @@ DRTEST_TEST(tags)
   DRTEST_FETCH(int, expected);
   auto sum = lhs + rhs;
   DRTEST_ASSERT_EQ(sum, expected);  // This will raise if row 2 or 3 are not skipped!
+}
+
+DRTEST_TEST(skip)
+{
+  drtest::skip();
+  throw std::logic_error{"this should never happen..."};
+}
+
+DRTEST_TEST(xfail)
+{
+  drtest::xfail();
+  DRTEST_ASSERT_EQ(2 + 2, 5);
 }

--- a/tests/Test.cpp
+++ b/tests/Test.cpp
@@ -229,3 +229,23 @@ DRTEST_TEST(addRow)
 {
   DRTEST_ASSERT(true);
 }
+
+DRTEST_DATA(tags)
+{
+  drtest::addColumn<int>("lhs");
+  drtest::addColumn<int>("rhs");
+  drtest::addColumn<int>("expected");
+
+  drtest::addRow("row 1", 1, 1, 2);
+  drtest::addRow("row 2", 2, 2, 5, drtest::Tag::skip);
+  drtest::addRow("row 3", 4, 4, 9, drtest::Tag::xfail);
+}
+
+DRTEST_TEST(tags)
+{
+  DRTEST_FETCH(int, lhs);
+  DRTEST_FETCH(int, rhs);
+  DRTEST_FETCH(int, expected);
+  auto sum = lhs + rhs;
+  DRTEST_ASSERT_EQ(sum, expected);  // This will raise if row 2 or 3 are not skipped!
+}

--- a/tests/Test.cpp
+++ b/tests/Test.cpp
@@ -250,6 +250,28 @@ DRTEST_TEST(tags)
   DRTEST_ASSERT_EQ(sum, expected);  // This will raise if row 2 or 3 are not skipped!
 }
 
+DRTEST_DATA(tagRow)
+{
+  drtest::addColumn<int>("lhs");
+  drtest::addColumn<int>("rhs");
+  drtest::addColumn<int>("expected");
+
+  drtest::addRow("row 1", 1, 1, 2);
+  drtest::addRow("row 2", 2, 2, 5);
+  drtest::addRow("row 3", 4, 4, 9, drtest::tags::skip);
+  drtest::tagRow("row 2", drtest::tags::skip);
+  drtest::tagRow("row 3", drtest::tags::xfail);
+}
+
+DRTEST_TEST(tagRow)
+{
+  DRTEST_FETCH(int, lhs);
+  DRTEST_FETCH(int, rhs);
+  DRTEST_FETCH(int, expected);
+  auto sum = lhs + rhs;
+  DRTEST_ASSERT_EQ(sum, expected);  // This will raise if row 2 or 3 are not skipped!
+}
+
 DRTEST_TEST(skip)
 {
   drtest::skip();


### PR DESCRIPTION
Allows users to tag rows or entire tests with `skip` or `xfail` markers. This requires reworking `TestObject::addRow` using fold expressions. The definition of bitwise operators for `enum class tags` using `inline` is a bit awkward and should be improved at a later point.